### PR TITLE
Update dev-repo

### DIFF
--- a/opam
+++ b/opam
@@ -10,7 +10,7 @@ authors: "the rmem developers (see homepage)"
 license: "2-Clause BSD"
 homepage: "https://github.com/rems-project/rmem"
 bug-reports: "https://github.com/rems-project/rmem/issues"
-dev-repo: "https://github.com/rems-project/rmem"
+dev-repo: "git://github.com:rems-project/rmem"
 depends: [ 
   "ocaml" {>= "4.06.1"}
   "ocamlfind"


### PR DESCRIPTION
When I'm trying to build rmem by `opam install .`, it says:

```
opam install . 
[NOTE] Ignoring uncommitted changes in /home/jeehoon.kang/Works/rmem (`--working-dir' not active).       
[rmem.0.1] synchronised from git+file:///home/jeehoon.kang/Works/rmem#master                             
[WARNING] Failed checks in opam file from upstream of rmem:                                              
    error 42: The 'dev-repo:' field doesn't use version control. You should use URLs of the form
              "git://", "git+https://", "hg+https://"...                                                 
Sorry, no solution found: there seems to be a problem with your request.
```

So I updated the dev-repo field in `opam`.

I'm on OCaml 4.10.0.