### PR TITLE
Fix dev-repo

### DIFF
--- a/opam
+++ b/opam
@@ -10,7 +10,7 @@ authors: "the rmem developers (see homepage)"
 license: "2-Clause BSD"
 homepage: "https://github.com/rems-project/rmem"
 bug-reports: "https://github.com/rems-project/rmem/issues"
-dev-repo: "git://github.com:rems-project/rmem"
+dev-repo: "git+https://github.com/rems-project/rmem.git"
 depends: [ 
   "ocaml" {>= "4.06.1"}
   "ocamlfind"


### PR DESCRIPTION
Sorry, I'm opening another PR on dev-repo.  It seems the right format for the field is "git+https://github.com/rems-project/rmem.git" (https://github.com/ocaml/opam/search?q=dev-repo&unscoped_q=dev-repo).

This time I checked docs carefully so that I believe the PR is correct.  @cp526 please have a look.