### PR TITLE
(opam) bump sail>=0.14

### DIFF
--- a/opam
+++ b/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlbuild"
   "lem" {>= "2018-12-14"}
   "linksem" {>= "0.3"}
-  "sail"
+  "sail" {>= "0.14"}
   "sail-riscv"
   "conf-gmp"
   "lwt" {>= "4.1.0" & <= "4.5.0"}


### PR DESCRIPTION
fixes #20

Should be done in conjunction with updating the rems-project opam repos to remove sail/lem/linksem probably