### PR TITLE
Add z3 to README debian dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The dependencies can be installed automatically as part of the rmem build proces
 In addition, a debian based Linux system also need the following packages:
 
 ``` shell
-sudo apt install findutils libgmp-dev m4 perl pkg-config zlib1g-dev
+sudo apt install findutils libgmp-dev m4 perl pkg-config zlib1g-dev z3
 ```
 
 


### PR DESCRIPTION
I have added `z3` to the (debian) dependencies list in the README.

I tried installing by following the instructions in a fresh debian/13 container but it failed while compiling `sail-riscv` with error `z3: not found`. Compilation worked after installing `z3`.